### PR TITLE
Further extend Error Handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,7 +322,11 @@ var icloud = {
 							} catch (err) {}
 						}
 					});
-				} 
+				} else if(resp) {
+					return callback("Login Error | Got "+resp.statusCode+" on Login");
+				} else {
+					return callback("Login Error | Login failed");
+				}
 
 				return callback(err, resp, body);
 			});
@@ -356,7 +360,7 @@ var icloud = {
 
 	getDevices: function(callback) {
 		icloud.init(function(error, response, body) {
-			if (response.statusCode == 450) {
+			if (response && response.statusCode == 450) {
 				try {
 					fs.unlinkSync("cookies.json");
 					icloud.login(() => {


### PR DESCRIPTION
I occasionally receive a 404 error in the onLogin function without a proper error callback. Status codes other than 450 have not been handled in the checkSession function so far.

Additionally, in the getDevices function, there was a check for response.statusCode == 450 without verifying the existence of the response variable beforehand, leading to unintended errors.

P.S.: I hope I've submitted this pull request correctly; I'm a GitHub newbie. 😉